### PR TITLE
[25.0] feat(datasets): add API endpoint to adopt local files and return Encoded dataset ID

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -4,6 +4,9 @@ API operations on the contents of a history dataset.
 
 import logging
 import os
+
+from pathlib import Path as path_suf
+
 from io import (
     BytesIO,
     IOBase,
@@ -29,6 +32,7 @@ from starlette.responses import (
 )
 from typing_extensions import Annotated
 
+from galaxy.model import Dataset
 from galaxy.datatypes.dataproviders.base import MAX_LIMIT
 from galaxy.schema import (
     FilterQueryParams,
@@ -74,9 +78,7 @@ from galaxy.webapps.galaxy.services.datasets import (
     UpdateObjectStoreIdPayload,
 )
 
-from galaxy.security.idencoding import IdAsLowercaseAlphanumEncodingHelper
-from galaxy.exceptions import ObjectAttributeInvalidException, RequestParameterInvalidException
-from bioblend.galaxy import GalaxyInstance
+from galaxy.exceptions import RequestParameterInvalidException
 
 log = logging.getLogger(__name__)
 
@@ -143,7 +145,6 @@ DisplayChunkSizeQueryParam = Query(
 @router.cbv
 class FastAPIDatasets:
     service: DatasetsService = depends(DatasetsService)
-    encoder = IdAsLowercaseAlphanumEncodingHelper(service.security)
 
     @router.get(
         "/api/datasets",
@@ -171,99 +172,105 @@ class FastAPIDatasets:
         summary="Return galaxy dataset id for local stored files."
     )
     async def adopt_local_file(
-        self,
-        request: Request,
-        file_path: str = Query(..., description="Absolute path to the local file"),
-        history_id: Optional[str] = Query(None, description="Input history id if available"),
-        extension: Optional[str] = Query(None, description="Input file extension if available"),
-        file_origin: Optional[Literal["annotation", "hypothesis"]] = Query(None, description="Source of the file either from hyp gen or annotation service"),
-        trans=DependsOnTrans,
-    ):
-        default_history_name = "GX_integration"
-
-        file_path = os.path.abspath(file_path)
-
-        if not os.path.exists(file_path):
-            raise RequestParameterInvalidException(f"File does not exist: {file_path}")
-
-        if not os.path.isfile(file_path):
-            raise RequestParameterInvalidException("Only regular files can be adopted")
-
-        if not os.access(file_path, os.R_OK):
-            raise RequestParameterInvalidException("Galaxy cannot read the file")
+            self,
+            file_path: str = Query(..., description="Absolute path to the l`ocal file"),
+            file_name: Optional[str] = Query(None, description = "Imported file name to be set on the history."),
+            extension: Optional[str] = Query(None, description="Input file extension if available"),
+            file_origin: Optional[Literal["annotation", "hypothesis"]] = Query(None, description="Source of the file either from hyp gen or annotation service"),
+            hist_id: Optional[str] = Query(None, description="Input history_id you want to import the dataset in."),
+            trans=DependsOnTrans,
+        ):
         
-        log.debug("adopt_local_file: file_validation_passed")
+            try:
+                history_id = None
+                default_history_name = "GX_integration"
 
-        
-        log.info(f"Adopting local file {file_path[:10]} into {history_id if history_id else file_origin}")
-        
-        if history_id:
-            log.info("using existing history, to add local file")
-            
-            history = self.service.history_manager.get_owned(
-                id = history_id,
-                user = trans.user
-                )
-            log.info("hda_created")
-                        
-        else:
-            
-            headers = request.headers
-            api_key = headers.get('x-api-key')
-            galaxy_url = str(request.base_url).rstrip("/")
-            
-            if not api_key:
-                raise RequestParameterInvalidException("Missing api-key header")
+                file_path = os.path.abspath(file_path)
 
-            gi = GalaxyInstance(url = galaxy_url, key = api_key)    
-        
-            if file_origin:
-                           
-                histories = gi.histories.get_histories(name = file_origin)
+                if not os.path.exists(file_path):
+                    raise RequestParameterInvalidException(f"File does not exist: {file_path}")
 
-                if histories:
-                    log.info(f"Fetching galaxy history with name {file_origin}")
-                    history_id = histories[0]["id"]
-                else:
-                    log.info(f"Creating galaxy history with name {file_origin}")
-                    new_history = gi.histories.create_history(name = file_origin)
-                    history_id = new_history["id"]
-                    
-            else:
-                log.warning("No history found to input the local file to, creating a new history.")
-                new_history = gi.histories.create_history(name = default_history_name)
-                history_id = new_history["id"]
+                if not os.path.isfile(file_path):
+                    raise RequestParameterInvalidException("Only regular files can be adopted")
+
+                if not os.access(file_path, os.R_OK):
+                    raise RequestParameterInvalidException("Galaxy cannot read the file")
                 
-            history = self.service.history_manager.get_owned(
-                id = history_id,
-                user = trans.user
-            )
+                log.debug("adopt_local_file: file_validation_passed")
+
+                
+                if hist_id:
+                    history_id = trans.security.decode_id(hist_id)
+                
+                else:
+                    histories = self.service.history_manager.by_user(trans.user)
+                    for his in histories:
+                        if his.name == file_origin:
+                            history_id = his.id
+                            break
+                                   
+                log.info(f"Adopting local file {file_path[:10]} into {history_id if history_id else file_origin}")
+                
+                # Determine or create the history
+                history = None
+                
+                try:
+                    if history_id:
+                        log.info("using existing history, to add local file")
+                        
+                        history = self.service.history_manager.get_owned(
+                            id = history_id,
+                            user = trans.user
+                            )
+                        log.info("hda_created")
+                                    
+                    else:
+                        
+                        log.info("history not found to input the local file to, creating a new history.")
+                        history_name = file_origin or default_history_name
+                        
+                        history = self.service.history_manager.create(name = history_name, user = trans.user)
+                except Exception as e:
+                    log.error(f"Error fetching or creating history to add local file to: {str(e)}")
+                    
+                
+                if not extension:
+                    extension = path_suf(file_path).suffix
+                    
+                # Create an empty HDA with the given extension
+                hda = self.service.hda_manager.create(history=history, extension=extension, visible=True)
+                log.info("hda_created succesfully")
+                
+                # Link the file (no data copy, mark non-purgable)
+                hda.link_to(file_path)
+                dataset = hda.dataset
+                log.info("Local file has been linked to history dataset successfully.")
+
+                hda.name = file_name or os.path.basename(file_path)
+                hda.state = Dataset.states.OK
+                
+                dataset.set_total_size()
+                hda.set_size()
+                hda.set_peek()
+                hda.init_meta(copy_from=None)
+                trans.sa_session.add(hda)
+                trans.sa_session.commit()
+                
+                trans.sa_session.add_all((hda, dataset) if hasattr(hda, "dataset") else (hda,))
+                trans.sa_session.commit()
+                trans.sa_session.flush()
+                
+                log.info("Local file has been linked to history dataset successfully.")            
+                log.info(f"updated the dataset state to: {hda.state}")
             
-            log.info("hda_created")
+            except Exception as exc:
+                log.error(f"Error caused during file adoption: {exc}")
+                
+            return {
+                    'dataset_id': trans.security.encode_id(hda.id), 
+                    'history_id': trans.security.encode_id(history.id)
+                }
             
-        # Create an empty HDA with the given extension
-        hda = self.service.hda_manager.create(history=history, extension=extension, visible=True)
-        
-        # Link the file (no data copy, mark non-purgable)
-        hda.link_to(file_path) # this is optional so we can't purge the dataset from galaxy.
-        log.info("Local file has been linked to history dataset successfully.")
-        
-        # NOTE: Available but not really usefull for our case, methods to Populate metadata and peek.
-        hda.init_meta(copy_from=None)
-        hda.set_meta()
-        hda.set_peek()
-        
-        # Save changes
-        # trans.sa_session.commit()
-        log.debug("Applying changes and flushing_session.")
-        trans.sa_session.flush()
-        log.info("Local file adoption_complete, into galaxy history.")
-        
-        return {
-            'dataset_id': self.encoder.encode_id(hda.id),
-            "history_id": history_id
-            }
-        
     @router.get(
         "/api/datasets/{dataset_id}/storage",
         summary="Display user-facing storage details related to the objectstore a dataset resides in.",

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -173,7 +173,7 @@ class FastAPIDatasets:
     )
     async def adopt_local_file(
             self,
-            file_path: str = Query(..., description="Absolute path to the l`ocal file"),
+            file_path: str = Query(..., description="Absolute path to the local file"),
             file_name: Optional[str] = Query(None, description = "Imported file name to be set on the history."),
             extension: Optional[str] = Query(None, description="Input file extension if available"),
             file_origin: Optional[Literal["annotation", "hypothesis"]] = Query(None, description="Source of the file either from hyp gen or annotation service"),
@@ -181,71 +181,98 @@ class FastAPIDatasets:
             trans=DependsOnTrans,
         ):
         
-            try:
-                history_id = None
-                default_history_name = "GX_integration"
+        try:
+            log.info(f"Starting adopt_local_file with file_path: {file_path[:50]}")  # Log start with truncated path for security
+            
+            history_id = None
+            default_history_name = "GX_integration"
+            history = None
+            hda = None
 
-                file_path = os.path.abspath(file_path)
+            file_path = os.path.abspath(file_path)
 
-                if not os.path.exists(file_path):
-                    raise RequestParameterInvalidException(f"File does not exist: {file_path}")
+            if not os.path.exists(file_path):
+                log.error(f"File does not exist: {file_path}")
+                raise RequestParameterInvalidException(f"File does not exist: {file_path}")
 
-                if not os.path.isfile(file_path):
-                    raise RequestParameterInvalidException("Only regular files can be adopted")
+            if not os.path.isfile(file_path):
+                log.error(f"Only regular files can be adopted: {file_path}")
+                raise RequestParameterInvalidException("Only regular files can be adopted")
 
-                if not os.access(file_path, os.R_OK):
-                    raise RequestParameterInvalidException("Galaxy cannot read the file")
-                
-                log.debug("adopt_local_file: file_validation_passed")
+            if not os.access(file_path, os.R_OK):
+                log.error(f"Galaxy cannot read the file: {file_path}")
+                raise RequestParameterInvalidException("Galaxy cannot read the file")
+            
+            log.debug("adopt_local_file: file_validation_passed")
 
-                
-                if hist_id:
-                    history_id = trans.security.decode_id(hist_id)
-                
-                else:
-                    histories = self.service.history_manager.by_user(trans.user)
-                    for his in histories:
-                        if his.name == file_origin:
-                            history_id = his.id
-                            break
-                                   
-                log.info(f"Adopting local file {file_path[:10]} into {history_id if history_id else file_origin}")
-                
-                # Determine or create the history
-                history = None
-                
+            
+            if hist_id:
                 try:
-                    if history_id:
-                        log.info("using existing history, to add local file")
-                        
-                        history = self.service.history_manager.get_owned(
-                            id = history_id,
-                            user = trans.user
-                            )
-                        log.info("hda_created")
-                                    
-                    else:
-                        
-                        log.info("history not found to input the local file to, creating a new history.")
-                        history_name = file_origin or default_history_name
-                        
-                        history = self.service.history_manager.create(name = history_name, user = trans.user)
+                    history_id = trans.security.decode_id(hist_id)
+                    log.debug(f"Decoded history_id: {history_id}")
                 except Exception as e:
-                    log.error(f"Error fetching or creating history to add local file to: {str(e)}")
-                    
+                    log.error(f"Error decoding hist_id: {str(e)}")
+            
+            if not history_id:
+                histories = self.service.history_manager.by_user(trans.user)
                 
-                if not extension:
+                for his in histories:
+                    if his.name == file_origin:
+                        history_id = his.id
+                        log.info(f"Found existing history with name: {file_origin}, id: {history_id}")
+                        break
+                            
+            log.info(f"Adopting local file {file_path[:10]} into {history_id if history_id else file_origin}")
+            
+            # Determine or create the history
+            try:
+                if history_id:
+                    log.info("Using existing history to add local file")
+                    
+                    history = self.service.history_manager.get_owned(
+                        id = history_id,
+                        user = trans.user
+                        )
+                    log.info(f"Retrieved existing history: {history.id}")
+                                
+                else:
+                    
+                    log.info("History not found to input the local file to, creating a new history.")
+                    history_name = file_origin or default_history_name
+                    
+                    history = self.service.history_manager.create(name = history_name, user = trans.user)
+                    log.info(f"Created new history: {history.id}")
+                    
+            except Exception as e:
+                log.error(f"Error fetching or creating history to add local file to: {str(e)}")
+                raise  # Re-raise to handle at outer level
+            
+            if not extension:
+                try:
                     extension = path_suf(file_path).suffix
-                    
-                # Create an empty HDA with the given extension
+                    log.debug(f"Determined extension from file: {extension}")
+                except Exception as e:
+                    log.error(f"Error determining file extension: {str(e)}")
+                    raise
+            
+            # Create an empty HDA with the given extension
+            try:
                 hda = self.service.hda_manager.create(history=history, extension=extension, visible=True)
-                log.info("hda_created succesfully")
-                
-                # Link the file (no data copy, mark non-purgable)
+                log.info("HDA created successfully")
+            except Exception as e:
+                log.error(f"Error creating HDA: {str(e)}")
+                raise
+            
+            # Link the file (no data copy, mark non-purgable)
+            try:
                 hda.link_to(file_path)
                 dataset = hda.dataset
                 log.info("Local file has been linked to history dataset successfully.")
+            except Exception as e:
+                log.error(f"Error linking file to HDA: {str(e)}")
+                raise
 
+            try:
                 hda.name = file_name or os.path.basename(file_path)
                 hda.state = Dataset.states.OK
                 
@@ -261,15 +288,27 @@ class FastAPIDatasets:
                 trans.sa_session.flush()
                 
                 log.info("Local file has been linked to history dataset successfully.")            
-                log.info(f"updated the dataset state to: {hda.state}")
-            
-            except Exception as exc:
-                log.error(f"Error caused during file adoption: {exc}")
-                
-            return {
-                    'dataset_id': trans.security.encode_id(hda.id), 
-                    'history_id': trans.security.encode_id(history.id)
-                }
+                log.info(f"Updated the dataset state to: {hda.state}")
+            except Exception as e:
+                log.error(f"Error updating HDA properties or committing session: {str(e)}")
+                raise
+        
+        except Exception as exc:
+            log.error(f"Error caused during file adoption: {str(exc)}")
+            raise  # Re-raise the exception to let the API handle it appropriately (e.g., return 400/500)
+        
+        try:
+            encoded_dataset_id =  trans.security.encode_id(hda.id)
+            encoded_history_id = trans.security.encode_id(history.id)
+        except Exception as exc:
+            log.error(f"Error encoding the dataset and history ids: {exc}") 
+            raise
+        
+        log.info("File adoption completed successfully")
+        return {
+                'dataset_id': encoded_dataset_id, 
+                'history_id': encoded_history_id
+            }
             
     @router.get(
         "/api/datasets/{dataset_id}/storage",

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -3,6 +3,7 @@ API operations on the contents of a history dataset.
 """
 
 import logging
+import os
 from io import (
     BytesIO,
     IOBase,
@@ -12,6 +13,7 @@ from typing import (
     cast,
     List,
     Optional,
+    Literal
 )
 
 from fastapi import (
@@ -71,6 +73,10 @@ from galaxy.webapps.galaxy.services.datasets import (
     RequestDataType,
     UpdateObjectStoreIdPayload,
 )
+
+from galaxy.security.idencoding import IdAsLowercaseAlphanumEncodingHelper
+from galaxy.exceptions import ObjectAttributeInvalidException, RequestParameterInvalidException
+from bioblend.galaxy import GalaxyInstance
 
 log = logging.getLogger(__name__)
 
@@ -137,6 +143,7 @@ DisplayChunkSizeQueryParam = Query(
 @router.cbv
 class FastAPIDatasets:
     service: DatasetsService = depends(DatasetsService)
+    encoder = IdAsLowercaseAlphanumEncodingHelper(service.security)
 
     @router.get(
         "/api/datasets",
@@ -158,6 +165,96 @@ class FastAPIDatasets:
         response.headers["total_matches"] = str(total_matches)
         return entries
 
+    # NOTE: API endpoint to adopt local files and return dataset_id
+    @router.post(
+        "/api/datasets/adopt_file",
+        summary="Return galaxy dataset id for local stored files."
+    )
+    async def adopt_local_file(
+        self,
+        request: Request,
+        file_path: str = Query(..., description="Absolute path to the local file"),
+        history_id: Optional[str] = Query(None, description="Input history id if available"),
+        extension: Optional[str] = Query(None, description="Input file extension if available"),
+        file_origin: Optional[Literal["annotation", "hypothesis"]] = Query(None, description="Source of the file either from hyp gen or annotation service"),
+        trans=DependsOnTrans,
+    ):
+        default_history_name = "GX_integration"
+
+        file_path = os.path.abspath(file_path)
+
+        if not os.path.exists(file_path):
+            raise RequestParameterInvalidException(f"File does not exist: {file_path}")
+
+        if not os.path.isfile(file_path):
+            raise RequestParameterInvalidException("Only regular files can be adopted")
+
+        if not os.access(file_path, os.R_OK):
+            raise RequestParameterInvalidException("Galaxy cannot read the file")
+
+        
+        log.info(f"Adopting local file {file_path[:10]} into {history_id if history_id else file_origin}")
+        
+        if history_id:
+            history = self.service.history_manager.get_owned(
+                id = history_id,
+                user = trans.user
+                )
+                        
+        else:
+            
+            headers = request.headers
+            api_key = headers.get('x-api-key')
+            galaxy_url = str(request.base_url).rstrip("/")
+            
+            if not api_key:
+                raise RequestParameterInvalidException("Missing api-key header")
+
+            gi = GalaxyInstance(url = galaxy_url, key = api_key)    
+        
+            if file_origin:
+                           
+                histories = gi.histories.get_histories(name = file_origin)
+
+                if histories:
+                    log.info(f"Fetching galaxy history with name {file_origin}")
+                    history_id = histories[0]["id"]
+                else:
+                    log.info(f"Creating galaxy history with name {file_origin}")
+                    new_history = gi.histories.create_history(name = file_origin)
+                    history_id = new_history["id"]
+                    
+            else:
+                log.warning("No history found to input the local file to, creating a new history.")
+                new_history = gi.histories.create_history(name = default_history_name)
+                history_id = new_history["id"]
+                
+            history = self.service.history_manager.get_owned(
+                id = history_id,
+                user = trans.user
+            )
+                
+        
+        # Create an empty HDA with the given extension
+        hda = self.service.hda_manager.create(history=history, extension=extension, visible=True)
+        
+        # Link the file (no data copy, mark non-purgable)
+        hda.link_to(file_path) # this is optional so we can't purge the dataset from galaxy.
+        
+        # NOTE: Available but not really usefull for our case, methods to Populate metadata and peek.
+        hda.init_meta(copy_from=None)
+        hda.set_meta()
+        hda.set_peek()
+        
+        # Save changes
+        # trans.sa_session.commit()
+        trans.sa_session.flush()
+        
+        return {
+            'dataset_id': self.encoder.encode_id(hda.id),
+            "history_id": history_id
+            }
+        
     @router.get(
         "/api/datasets/{dataset_id}/storage",
         summary="Display user-facing storage details related to the objectstore a dataset resides in.",

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -191,15 +191,20 @@ class FastAPIDatasets:
 
         if not os.access(file_path, os.R_OK):
             raise RequestParameterInvalidException("Galaxy cannot read the file")
+        
+        log.debug("adopt_local_file: file_validation_passed")
 
         
         log.info(f"Adopting local file {file_path[:10]} into {history_id if history_id else file_origin}")
         
         if history_id:
+            log.info("using existing history, to add local file")
+            
             history = self.service.history_manager.get_owned(
                 id = history_id,
                 user = trans.user
                 )
+            log.info("hda_created")
                         
         else:
             
@@ -233,13 +238,15 @@ class FastAPIDatasets:
                 id = history_id,
                 user = trans.user
             )
-                
-        
+            
+            log.info("hda_created")
+            
         # Create an empty HDA with the given extension
         hda = self.service.hda_manager.create(history=history, extension=extension, visible=True)
         
         # Link the file (no data copy, mark non-purgable)
         hda.link_to(file_path) # this is optional so we can't purge the dataset from galaxy.
+        log.info("Local file has been linked to history dataset successfully.")
         
         # NOTE: Available but not really usefull for our case, methods to Populate metadata and peek.
         hda.init_meta(copy_from=None)
@@ -248,7 +255,9 @@ class FastAPIDatasets:
         
         # Save changes
         # trans.sa_session.commit()
+        log.debug("Applying changes and flushing_session.")
         trans.sa_session.flush()
+        log.info("Local file adoption_complete, into galaxy history.")
         
         return {
             'dataset_id': self.encoder.encode_id(hda.id),


### PR DESCRIPTION
This PR introduces a new datasets API endpoint that allows Galaxy to adopt existing local files into a user history without copying data. The endpoint validates the local file, links it directly to a newly created HistoryDatasetAssociation (HDA), and returns encoded dataset and history identifiers, for further computation on that dataset using galaxy tools and worklfows.

## Key Changes

### New API Endpoint

* **POST `/api/datasets/adopt_file`**

  * Adopts a locally stored file into a Galaxy history.
  * Returns:

    * `dataset_id` (encoded)
    * `history_id` (encoded)

### Supported Query Parameters

* `file_path` (required): Absolute path to a readable local file.
* `file_name` (optional): Name assigned to the dataset in the history.
* `extension` (optional): Dataset extension; inferred from file suffix if omitted.
* `file_origin` (optional): Source identifier (`annotation` or `hypothesis`), used for history selection/creation.
* `hist_id` (optional): Target history ID (encoded). If absent, history is inferred or created.

### History Resolution Logic

* If `hist_id` is provided and decodable, the dataset is added to that history.
* Otherwise, an existing history matching `file_origin` is reused.
* If no suitable history exists, a new one is created (`file_origin` or default `GX_integration`).

### Dataset Adoption Behavior

* Creates an empty HDA with the specified extension.
* Links the local file via `hda.link_to()` (no data copy).
* Marks the dataset as non-purgable and sets:

  * size
  * peek
  * metadata
  * state (`OK`)
* Commits changes through the SQLAlchemy session.

## Motivation

This endpoint enables tighter integration with external services that already manage files on disk (e.g. hypothesis generation, annotation services), avoiding unnecessary I/O and data duplication. It provides a controlled, auditable way to expose local files as Galaxy datasets while preserving Galaxy’s internal data model and security mechanisms.
